### PR TITLE
Setup initial CircleCI config and fix Travis CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,66 @@
+version: 2.1
+
+orbs:
+  go: circleci/go@1.2
+
 defaults: &defaults
   docker:
       - image: bepsays/ci-goreleaser:1.14.3
   environment:
     CGO_ENABLED: "0"
 
-version: 2
+workflows:
+  main:
+    jobs:
+      - test
+  release:
+      jobs:  
+        - build:
+            filters:
+              branches:
+                only: /release-.*/
+        - hold:
+            type: approval
+            requires:
+              - build
+        - release:
+            context: org-global
+            requires:
+              - hold
 jobs:
+  test:
+    machine:
+      image: ubuntu-1604:202004-01
+    environment:
+      #CGO_ENABLED: "1"
+      HUGO_BUILD_TAGS: "extended"
+      GO111MODULE: "on"
+    working_directory: "~/gotham"
+    steps:
+      - checkout
+      - go/install:
+          version: 1.14.3
+      - run:
+          name: "Install Mage"
+          command: |
+            curl -sSL "https://github.com/magefile/mage/releases/download/v1.9.0/mage_1.9.0_Linux-64bit.tar.gz" | sudo tar -xz --no-same-owner -C /usr/local/bin mage
+            mage --version
+      - run:
+          name: "Pull & Verify Dependencies"
+          command: |
+            go mod download
+            go mod verify
+      - run:
+          name: "Mage Test"
+          command: mage -v test
+      - run:
+          name: "Mage Check"
+          command: mage -v check
+      - run:
+          name: "Build Binary"
+          command: |
+            mage -v gotham
+            ./gotham version
   build:
     <<: *defaults
     steps:
@@ -33,20 +88,3 @@ jobs:
                     git config --global user.email "bjorn.erik.pedersen+hugoreleaser@gmail.com"
                     git config --global user.name "hugoreleaser"
                     go run -tags release main.go release -r ${CIRCLE_BRANCH}
-
-workflows:
-  version: 2
-  release:
-      jobs:  
-        - build:
-            filters:
-              branches:
-                only: /release-.*/
-        - hold:
-            type: approval
-            requires:
-              - build
-        - release:
-            context: org-global
-            requires:
-              - hold

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,29 +14,18 @@ git:
 go:
   - "1.13.11"
   - "1.14.3"
-  - master
+  - "master"
 
 arch:
   - amd64
-  - arm64
 
 os:
   - linux
-  - osx
-  - windows
 
 jobs:
   allow_failures:
     - go: master
-    - arch: arm64
   fast_finish: true
-  exclude:
-    - os: windows
-      go: master
-    - arch: arm64
-      os: osx
-    - arch: arm64
-      os: windows
 
 cache:
   directories:
@@ -47,20 +36,15 @@ cache:
 
 before_install:
   - df -h
-    # https://travis-ci.community/t/go-cant-find-gcc-with-go1-11-1-on-windows/293/5
-  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then
-        choco install mingw -y;
-        export PATH=/c/tools/mingw64/bin:"$PATH";
-    fi
   - gem install asciidoctor
   - type asciidoctor
 
 install:
   - mkdir -p $HOME/src
   - mv $TRAVIS_BUILD_DIR $HOME/src
-  - export TRAVIS_BUILD_DIR=$HOME/src/hugo
-  - cd $HOME/src/hugo
-  - go get github.com/magefile/mage
+  - export TRAVIS_BUILD_DIR=$HOME/src/gotham
+  - cd $HOME/src/gotham
+  - curl -sSL "https://github.com/magefile/mage/releases/download/v1.9.0/mage_1.9.0_Linux-64bit.tar.gz" | sudo tar -xz -C /usr/local/bin mage
 
 script:
   - go mod download
@@ -71,7 +55,7 @@ script:
     else
         HUGO_TIMEOUT=30000 mage -v check;
     fi
-  - mage -v hugo
-  - ./hugo -s docs/
-  - ./hugo --renderToMemory -s docs/
+  - mage -v gotham
+  - ./gotham -s docs/
+  - ./gotham --renderToMemory -s docs/
   - df -h

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,174 +1,77 @@
-project_name: hugo
+project_name: gotham
 env:
-  - GO111MODULE=on
-  - GOPROXY=https://proxy.golang.org
+  - CGO_ENABLED=1
 before:
   hooks:
     - go mod download
 builds:
-  -
-    binary: hugo
-    id: hugo
-    ldflags: -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash={{ .ShortCommit }}
-    env:
-      - CGO_ENABLED=0
+  - id: linux
+    flags:
+      - -tags
+      - extended
     goos:
-      - darwin
       - linux
-      - windows
-      - freebsd
-      - netbsd
-      - openbsd
-      - dragonfly
     goarch:
       - amd64
-      - 386
-      - arm
-      - arm64
-    goarm:
-      - 7
-
-  -
-    binary: hugo
-    id: hugo_extended_windows
     ldflags:
       - -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash={{ .ShortCommit }}
-      - "-extldflags '-static'"
-    env:
-      - CGO_ENABLED=1
-      - CC=x86_64-w64-mingw32-gcc
-      - CXX=x86_64-w64-mingw32-g++
-    flags:
-      - -tags
-      - extended
-    goos:
-      - windows
-    goarch:
-      - amd64
-  - binary: hugo
-    id: hugo_extended_darwin
-    ldflags: -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash={{ .ShortCommit }}
-    env:
-      - CGO_ENABLED=1
-      - CC=o64-clang
-      - CXX=o64-clang++
-    flags:
-      - -tags
-      - extended
-    goos:
-      - darwin
-    goarch:
-      - amd64
-  - binary: hugo
-    id: hugo_extended_linux
-    ldflags: -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash={{ .ShortCommit }}
-    env:
-      - CGO_ENABLED=1
-    flags:
-      - -tags
-      - extended
-    goos:
-      - linux
-    goarch:
-      - amd64
-
-release:
-  draft: true
+  #- id: macos
+  #env:
+  #    - CC=o64-clang
+  #    - CXX=o64-clang++
+  #  flags:
+  #    - -tags
+  #    - extended
+  #  goos:
+  #    - darwin
+  #  goarch:
+  #    - amd64
+  #  ldflags:
+  #    - -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash={{ .ShortCommit }}
+  #-
+  #  id: windows
+  #  env:
+  #    - CC=x86_64-w64-mingw32-gcc
+  #    - CXX=x86_64-w64-mingw32-g++
+  #  flags:
+  #    - -tags
+  #    - extended
+  #  goos:
+  #    - windows
+  #  goarch:
+  #    - amd64
+  #  ldflags:
+  #    - -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash={{ .ShortCommit }}
+  #    - "-extldflags '-static'"
 
 archives:
   -
-    id: "hugo"
-    builds: ['hugo']
+    builds:
+      - linux
+      #- macos
+      #- windows
     format: tar.gz
     format_overrides:
       - goos: windows
         format: zip
-    name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
+    name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     replacements:
-      amd64: 64bit
-      386: 32bit
-      arm: ARM
-      arm64: ARM64
-      darwin: macOS
-      linux: Linux
-      windows: Windows
-      openbsd: OpenBSD
-      netbsd: NetBSD
-      freebsd: FreeBSD
-      dragonfly: DragonFlyBSD
-    files:
-      - README.md
-      - LICENSE
-  -
-    id: "hugo_extended"
-    builds: ['hugo_extended_windows', 'hugo_extended_linux', 'hugo_extended_darwin']
-    format: tar.gz
-    format_overrides:
-      - goos: windows
-        format: zip
-    name_template: "{{.ProjectName}}_extended_{{.Version}}_{{.Os}}-{{.Arch}}"
-    replacements:
-      amd64: 64bit
-      386: 32bit
-      arm: ARM
-      arm64: ARM64
-      darwin: macOS
-      linux: Linux
-      windows: Windows
-      openbsd: OpenBSD
-      netbsd: NetBSD
-      freebsd: FreeBSD
-      dragonfly: DragonFlyBSD
+      darwin: macos
     files:
       - README.md
       - LICENSE
 
 nfpms:
   -
-    id: "hugo"
-    builds: ['hugo']
+    builds:
+      - linux
     formats:
         - deb
-    vendor: "gohugo.io"
-    homepage: "https://gohugo.io/"
-    maintainer: "Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>"
-    description: "A Fast and Flexible Static Site Generator built with love in GoLang."
+    vendor: "GothamHQ"
+    homepage: "https://GothamHQ.com"
+    maintainer: "GothamHQ Team <Team@GothamHQ.com>"
+    description: "An awesome static site generator."
     license: "Apache 2.0"
-    name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
+    file_name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     replacements:
-      amd64: 64bit
-      386: 32bit
-      arm: ARM
-      arm64: ARM64
-      darwin: macOS
-      linux: Linux
-      windows: Windows
-      openbsd: OpenBSD
-      netbsd: NetBSD
-      freebsd: FreeBSD
-      dragonfly: DragonFlyBSD
-  -
-    id: "hugo_extended"
-    builds: ['hugo_extended_linux']
-    formats:
-        - deb
-    vendor: "gohugo.io"
-    homepage: "https://gohugo.io/"
-    maintainer: "Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>"
-    description: "A Fast and Flexible Static Site Generator built with love in GoLang."
-    license: "Apache 2.0"
-    name_template: "{{.ProjectName}}_extended_{{.Version}}_{{.Os}}-{{.Arch}}"
-    replacements:
-      amd64: 64bit
-      386: 32bit
-      arm: ARM
-      arm64: ARM64
-      darwin: macOS
-      linux: Linux
-      windows: Windows
-      openbsd: OpenBSD
-      netbsd: NetBSD
-      freebsd: FreeBSD
-      dragonfly: DragonFlyBSD
-
-      
+      darwin: macos

--- a/hugolib/hugo_modules_test.go
+++ b/hugolib/hugo_modules_test.go
@@ -50,7 +50,7 @@ workingDir = %q
 
 [module]
 [[module.imports]]
-path="github.com/gothamhq/gothamTestModule2"
+path="github.com/gohugoio/hugoTestModule2"
   [[module.imports.mounts]]
     source = "templates/hooks"
     target = "layouts/_default/_markup"
@@ -78,8 +78,8 @@ module github.com/gohugoio/tests/testHugoModules
 `)
 
 	b.WithSourceFile("go.sum", `
-github.com/gothamhq/gothamTestModule2 v0.0.0-20200131160637-9657d7697877 h1:WLM2bQCKIWo04T6NsIWsX/Vtirhf0TnpY66xyqGlgVY=
-github.com/gothamhq/gothamTestModule2 v0.0.0-20200131160637-9657d7697877/go.mod h1:CBFZS3khIAXKxReMwq0le8sEl/D8hcXmixlOHVv+Gd0=
+github.com/gohugoio/hugoTestModule2 v0.0.0-20200131160637-9657d7697877 h1:WLM2bQCKIWo04T6NsIWsX/Vtirhf0TnpY66xyqGlgVY=
+github.com/gohugoio/hugoTestModule2 v0.0.0-20200131160637-9657d7697877/go.mod h1:CBFZS3khIAXKxReMwq0le8sEl/D8hcXmixlOHVv+Gd0=
 `)
 
 	b.Build(BuildCfg{})

--- a/hugolib/hugo_sites_build_errors_test.go
+++ b/hugolib/hugo_sites_build_errors_test.go
@@ -48,7 +48,7 @@ func TestSiteBuildErrors(t *testing.T) {
 		single      = "single"
 	)
 
-	// TODO(bep) add content tests after https://github.com/gothamhq/gotham/issues/5324
+	// TODO(bep) add content tests after https://github.com/gohugoio/hugo/issues/5324
 	// is implemented.
 
 	tests := []struct {

--- a/magefile.go
+++ b/magefile.go
@@ -48,11 +48,11 @@ func Gotham() error {
 }
 
 // Build hugo binary with race detector enabled
-func HugoRace() error {
+func GothamRace() error {
 	return sh.RunWith(flagEnv(), goexe, "build", "-race", "-ldflags", ldflags, "-tags", buildTags(), packageName)
 }
 
-// Install hugo binary
+// Install gotham binary
 func Install() error {
 	return sh.RunWith(flagEnv(), goexe, "install", "-ldflags", ldflags, "-tags", buildTags(), packageName)
 }
@@ -171,7 +171,7 @@ func Test() error {
 // Run tests with race detector
 func TestRace() error {
 	env := map[string]string{"GOFLAGS": testGoFlags()}
-	return runCmd(env, goexe, "test", "-race", "./...", "-tags", buildTags())
+	return runCmd(env, goexe, "test", "-p 1", "-race", "./...", "-tags", buildTags())
 }
 
 // Run gofmt linter
@@ -179,7 +179,7 @@ func Fmt() error {
 	if !isGoLatest() {
 		return nil
 	}
-	pkgs, err := hugoPackages()
+	pkgs, err := gothamPackages()
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ var (
 	pkgsInit     sync.Once
 )
 
-func hugoPackages() ([]string, error) {
+func gothamPackages() ([]string, error) {
 	var err error
 	pkgsInit.Do(func() {
 		var s string
@@ -239,7 +239,7 @@ func hugoPackages() ([]string, error) {
 
 // Run golint linter
 func Lint() error {
-	pkgs, err := hugoPackages()
+	pkgs, err := gothamPackages()
 	if err != nil {
 		return err
 	}
@@ -280,7 +280,7 @@ func TestCoverHTML() error {
 	if _, err := f.Write([]byte("mode: count")); err != nil {
 		return err
 	}
-	pkgs, err := hugoPackages()
+	pkgs, err := gothamPackages()
 	if err != nil {
 		return err
 	}

--- a/releaser/releaser.go
+++ b/releaser/releaser.go
@@ -137,7 +137,7 @@ func (r *ReleaseHandler) Run() error {
 	defer r.gitPush() // TODO(bep)
 
 	if prepareRelaseNotes || shouldRelease {
-		gitCommits, err = getGitInfos(changeLogFromTag, "hugo", "", !r.try)
+		gitCommits, err = getGitInfos(changeLogFromTag, "gotham", "", !r.try)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
From Hugo, CircleCI was exclusively used for releases only. This PR enables CircleCI to do complete testing on Gotham.

It also has a few tweaks to the existing Travis CI build to work with Gotham.

Closes #3.