### PR TITLE
Setup GoReleaser for Linux & macOS.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,38 +3,34 @@ version: 2.1
 orbs:
   go: circleci/go@1.2
 
-defaults: &defaults
-  docker:
-      - image: bepsays/ci-goreleaser:1.14.3
-  environment:
-    CGO_ENABLED: "0"
-
 workflows:
   main:
     jobs:
       - test-on-linux
       - test-on-macos
-  release:
-      jobs:  
-        - build:
-            filters:
-              branches:
-                only: /release-.*/
-        - hold:
-            type: approval
-            requires:
-              - build
-        - release:
-            context: org-global
-            requires:
-              - hold
+      - release-on-linux:
+          requires:
+            - test-on-linux
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
+          context: main-context
+      - release-on-macos:
+          requires:
+            - release-on-linux
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
+          context: main-context
+
 jobs:
   test-on-linux:
     machine:
       image: ubuntu-1604:202004-01
-    environment:
-      HUGO_BUILD_TAGS: "extended"
-      GO111MODULE: "on"
     working_directory: "~/gotham"
     steps:
       - checkout
@@ -111,30 +107,39 @@ jobs:
           command: |
             mage -v gotham
             ./gotham version
-  build:
-    <<: *defaults
+  release-on-linux:
+    machine:
+      image: ubuntu-1604:202004-01
+    working_directory: "~/gotham"
     steps:
-      - checkout:
-          path: hugo
+      - checkout
+      - go/install:
+          version: 1.14.4
       - run:
-            command: |
-                git clone git@github.com:gohugoio/hugoDocs.git
-                cd hugo
-                go mod download
-                sleep 5
-                go mod verify
-                go test -p 1 ./...
-      - persist_to_workspace:
-          root: .
-          paths: .
-  release:
-    <<: *defaults
+          name: "Install GoReleaser"
+          command: |
+            curl -sSL "https://github.com/goreleaser/goreleaser/releases/download/v0.137.0/goreleaser_Linux_x86_64.tar.gz" | sudo tar -xz -C /usr/local/bin goreleaser
+            goreleaser --version
+      - run:
+          name: "Release"
+          command: |
+            goreleaser release --config=.goreleaser.linux.yml
+  release-on-macos:
+    macos:
+      xcode: 11.5.0
+    working_directory: "~/gotham"
     steps:
-      - attach_workspace:
-          at: /root/project
+      - checkout
+      # https://github.com/CircleCI-Public/go-orb/issues/37
       - run:
-            command: |
-                    cd hugo
-                    git config --global user.email "bjorn.erik.pedersen+hugoreleaser@gmail.com"
-                    git config --global user.name "hugoreleaser"
-                    go run -tags release main.go release -r ${CIRCLE_BRANCH}
+          name: "Install Go"
+          command: brew install go
+      - run:
+          name: "Install GoReleaser"
+          command: |
+            curl -sSL "https://github.com/goreleaser/goreleaser/releases/download/v0.137.0/goreleaser_Darwin_x86_64.tar.gz" | sudo tar -xz -C /usr/local/bin goreleaser
+            goreleaser --version
+      - run:
+          name: "Release"
+          command: |
+            goreleaser release --config=.goreleaser.macos.yml

--- a/.goreleaser.linux.yml
+++ b/.goreleaser.linux.yml
@@ -1,0 +1,34 @@
+project_name: gotham
+before:
+  hooks:
+    - go mod download
+builds:
+  - goos:
+      - linux
+    goarch:
+      - amd64
+    ldflags:
+      - -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash=
+
+archives:
+  -
+    format: tar.gz
+    name_template: "{{.ProjectName}}-v{{.Version}}-{{.Os}}-{{.Arch}}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    files:
+      - README.md
+      - LICENSE
+
+#nfpms:
+  #-
+    #builds:
+    #  - linux
+    #formats:
+    #    - deb
+    #vendor: "GothamHQ"
+    #homepage: "https://GothamHQ.com"
+    #maintainer: "GothamHQ Team <Team@GothamHQ.com>"
+    #description: "An awesome static site generator."
+    #license: "Apache 2.0"
+    #file_name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+changelog:
+  skip: true

--- a/.goreleaser.macos.yml
+++ b/.goreleaser.macos.yml
@@ -1,0 +1,25 @@
+project_name: gotham
+before:
+  hooks:
+    - go mod download
+builds:
+  #- env:
+  #    - CC=o64-clang
+  #    - CXX=o64-clang++
+  - goos:
+      - darwin
+    goarch:
+      - amd64
+    ldflags:
+      - -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash=
+
+archives:
+  - format: tar.gz
+    name_template: "{{.ProjectName}}-v{{.Version}}-{{.Os}}-{{.Arch}}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    replacements:
+      darwin: macos
+    files:
+      - README.md
+      - LICENSE
+changelog:
+  skip: true

--- a/.goreleaser.windows.yml
+++ b/.goreleaser.windows.yml
@@ -1,33 +1,17 @@
 project_name: gotham
-env:
-  - CGO_ENABLED=1
 before:
   hooks:
     - go mod download
 builds:
-  - id: linux
-    flags:
-      - -tags
-      - extended
+  - env:
+      - CC=o64-clang
+      - CXX=o64-clang++
     goos:
-      - linux
+      - darwin
     goarch:
       - amd64
     ldflags:
       - -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash={{ .ShortCommit }}
-  #- id: macos
-  #env:
-  #    - CC=o64-clang
-  #    - CXX=o64-clang++
-  #  flags:
-  #    - -tags
-  #    - extended
-  #  goos:
-  #    - darwin
-  #  goarch:
-  #    - amd64
-  #  ldflags:
-  #    - -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash={{ .ShortCommit }}
   #-
   #  id: windows
   #  env:

--- a/common/hugo/version.go
+++ b/common/hugo/version.go
@@ -73,7 +73,7 @@ func (h VersionString) Eq(other interface{}) bool {
 	return s == h.String()
 }
 
-var versionSuffixes = []string{"-test", "-DEV"}
+var versionSuffixes = []string{"-test", "-DEV", "-dev"}
 
 // ParseVersion parses a version string.
 func ParseVersion(s string) (Version, error) {

--- a/common/hugo/version_current.go
+++ b/common/hugo/version_current.go
@@ -16,7 +16,7 @@ package hugo
 // CurrentVersion represents the current build version.
 // This should be the only one.
 var CurrentVersion = Version{
-	Number:     0.72,
+	Number:     0.1,
 	PatchLevel: 0,
-	Suffix:     "",
+	Suffix:     "-dev",
 }

--- a/modules/config_test.go
+++ b/modules/config_test.go
@@ -30,10 +30,9 @@ func TestConfigHugoVersionIsValid(t *testing.T) {
 		in     HugoVersion
 		expect bool
 	}{
-		{HugoVersion{Min: "0.33.0"}, true},
-		{HugoVersion{Min: "0.56.0-DEV"}, true},
-		{HugoVersion{Min: "0.33.0", Max: "0.55.0"}, false},
-		{HugoVersion{Min: "0.33.0", Max: "0.99.0"}, true},
+		{HugoVersion{Min: "0.1.0-dev"}, true},
+		{HugoVersion{Min: "0.0.0", Max: "0.0.0"}, false},
+		{HugoVersion{Min: "0.1.0-dev", Max: "0.99.0"}, true},
 	} {
 		c.Assert(test.in.IsValid(), qt.Equals, test.expect)
 	}
@@ -45,8 +44,8 @@ func TestDecodeConfig(t *testing.T) {
 [module]
 
 [module.hugoVersion]
-min = "0.54.2"
-max = "0.99.0"
+min = "0.0.0"
+max = "0.2.0"
 extended = true
 
 [[module.mounts]]
@@ -69,7 +68,7 @@ lang="en"
 	mcfg, err := DecodeConfig(cfg)
 	c.Assert(err, qt.IsNil)
 
-	v056 := hugo.VersionString("0.56.0")
+	v056 := hugo.VersionString("0.1.0")
 
 	hv := mcfg.HugoVersion
 


### PR DESCRIPTION
GoReleaser is setup to support releasing from Linux and macOS. For now, changelogs are off since we don't have any releases yet.