### PR TITLE
Correct checksum file naming.

### DIFF
--- a/.goreleaser.linux.yml
+++ b/.goreleaser.linux.yml
@@ -1,7 +1,9 @@
 project_name: gotham
+
 before:
   hooks:
     - go mod download
+
 builds:
   - goos:
       - linux
@@ -11,12 +13,14 @@ builds:
       - -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash=
 
 archives:
-  -
-    format: tar.gz
-    name_template: "{{.ProjectName}}-v{{.Version}}-{{.Os}}-{{.Arch}}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     files:
       - README.md
       - LICENSE
+
+checksum:
+  name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}-checksum.txt"
 
 #nfpms:
   #-

--- a/.goreleaser.macos.yml
+++ b/.goreleaser.macos.yml
@@ -1,11 +1,10 @@
 project_name: gotham
+
 before:
   hooks:
     - go mod download
+
 builds:
-  #- env:
-  #    - CC=o64-clang
-  #    - CXX=o64-clang++
   - goos:
       - darwin
     goarch:
@@ -21,5 +20,9 @@ archives:
     files:
       - README.md
       - LICENSE
+
+checksum:
+  name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}-checksum.txt"
+
 changelog:
   skip: true


### PR DESCRIPTION
Make the checksum files between Linux and macOS have unique names. This
will prevent a failed CI build during releases going forward.

Aside from the main change, there's spaces added to some template tags to make them more consistent. I also add a newline before every top level key, again for legibility.

Fixes #21.