### PR TITLE
Enhance the version command.

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -15,6 +15,8 @@
 package commands
 
 import (
+	"errors"
+
 	"github.com/gothamhq/gotham/common/hugo"
 	"github.com/spf13/cobra"
 
@@ -27,16 +29,37 @@ type versionCmd struct {
 	*baseCmd
 }
 
+var vType string
+
 func newVersionCmd() *versionCmd {
-	return &versionCmd{
+
+	vc := &versionCmd{
 		newBaseCmd(&cobra.Command{
 			Use:   "version",
 			Short: "Print the version number of Gotham",
 			Long: `This will print the Gotham and Hugo version numbers. There
-			are flags available to print just the Gotham version for scripting.`,
-			Run: func(cmd *cobra.Command, args []string) {
-				jww.FEEDBACK.Println(hugo.PrintGothamVersion(hugo.VersionRegular))
+are flags available to print just the Gotham version for scripting.`,
+			RunE: func(cmd *cobra.Command, args []string) error {
+
+				var theType hugo.VersionType
+
+				if vType == "regular" {
+					theType = hugo.VersionRegular
+				} else if vType == "short" {
+					theType = hugo.VersionShort
+				} else if vType == "detailed" {
+					theType = hugo.VersionDetailed
+				} else {
+					return errors.New("Invalid value for --type.")
+				}
+
+				jww.FEEDBACK.Println(hugo.PrintGothamVersion(theType))
+				return nil
 			},
 		}),
 	}
+
+	vc.cmd.Flags().StringVarP(&vType, "type", "", "regular", "level of information to display: short, regular, or detailed")
+
+	return vc
 }

--- a/common/hugo/semver-version.go
+++ b/common/hugo/semver-version.go
@@ -5,6 +5,7 @@ package hugo
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 )
 
@@ -39,6 +40,10 @@ func (v SemVerVersion) String() string {
 // Build complete version string for user via CLI
 func PrintGothamVersion(vType VersionType) string {
 
+	if vType == VersionShort {
+		return GothamVersion.String()
+	}
+
 	version := "Gotham v" + GothamVersion.String()
 
 	if commitHash != "" {
@@ -52,6 +57,20 @@ func PrintGothamVersion(vType VersionType) string {
 	}
 
 	version += ")"
+
+	if vType == VersionRegular {
+		return version
+	}
+
+	version += "\n"
+
+	date := buildDate
+	if date == "" {
+		date = "unknown"
+	}
+
+	version += "BuildDate: " + date + "\n"
+	version += "Platform: " + runtime.GOOS + "/" + runtime.GOARCH
 
 	return version
 }


### PR DESCRIPTION
Added the flag support for short and detailed.

Here's an example of output for the dev version:

```bash
Gotham v0.2.0-dev (compatible with Hugo v0.72.0/extended)
BuildDate: unknown
Platform: linux/amd64
```
Closes #17.