### PR TITLE
Enable page exclusion from sitemap.xml

### DIFF
--- a/config/commonConfig.go
+++ b/config/commonConfig.go
@@ -81,6 +81,7 @@ type Sitemap struct {
 	ChangeFreq string
 	Priority   float64
 	Filename   string
+	Exclude    bool
 }
 
 func DecodeSitemap(prototype Sitemap, input map[string]interface{}) Sitemap {
@@ -93,6 +94,8 @@ func DecodeSitemap(prototype Sitemap, input map[string]interface{}) Sitemap {
 			prototype.Priority = cast.ToFloat64(value)
 		case "filename":
 			prototype.Filename = cast.ToString(value)
+		case "exclude":
+			prototype.Exclude = cast.ToBool(value)
 		default:
 			jww.WARN.Printf("Unknown Sitemap field: %s\n", key)
 		}

--- a/hugolib/sitemap_test.go
+++ b/hugolib/sitemap_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const sitemapTemplate = `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {{ range .Data.Pages }}
+  {{ range where .Pages ".Sitemap.Exclude" false }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -87,11 +87,12 @@ func doTestSitemapOutput(t *testing.T, internal bool) {
 
 func TestParseSitemap(t *testing.T) {
 	t.Parallel()
-	expected := config.Sitemap{Priority: 3.0, Filename: "doo.xml", ChangeFreq: "3"}
+	expected := config.Sitemap{Priority: 3.0, Filename: "doo.xml", ChangeFreq: "3", Exclude: true}
 	input := map[string]interface{}{
 		"changefreq": "3",
 		"priority":   3.0,
 		"filename":   "doo.xml",
+		"exclude":    true,
 		"unknown":    "ignore",
 	}
 	result := config.DecodeSitemap(config.Sitemap{}, input)

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -61,7 +61,7 @@ var EmbeddedTemplates = [][2]string{
 	{`_default/sitemap.xml`, `{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range .Data.Pages }}
+  {{ range where .Pages ".Sitemap.Exclude" false }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
@@ -79,7 +79,8 @@ var EmbeddedTemplates = [][2]string{
                 />{{ end }}
   </url>
   {{ end }}
-</urlset>`},
+</urlset>
+`},
 	{`_default/sitemapindex.xml`, `{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 	{{ range . }}

--- a/tpl/tplimpl/embedded/templates/_default/sitemap.xml
+++ b/tpl/tplimpl/embedded/templates/_default/sitemap.xml
@@ -1,7 +1,7 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range .Data.Pages }}
+  {{ range where .Pages ".Sitemap.Exclude" false }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}


### PR DESCRIPTION
This PR adds a new key to .Sitemap called `Exclude`. `Exclude` is a
boolean that is set to false by default meaning all available pages are
included. This is the behavior currently. When `Exclude` is set to true,
it will not appear in any `sitemap.xml` files that Hugo may generate.

`Exclude` can be set to true in the Hugo config turning `sitemap.xml`
into an opt-in rather than an opt-out.

fixes: #28 