### PR TITLE
Add NewTab property to Gotham menus

### DIFF
--- a/gotham-features.md
+++ b/gotham-features.md
@@ -28,3 +28,26 @@ My page.... blah blah blah.
 
 While this setting can be done page-by-page to opt them out of the sitemap, you can also set this in your Gotham config file to opt-out all pages by default.
 Then, you can manually opt-in pages.
+
+### Menu Items Support Opening in New Tabs
+
+If you have a menu item that you'd prefer to open in a new tab (or window, depending on browser), you can now do so via the Gotham config file.
+Here's an example:
+
+```yaml
+#... gotham config
+
+menu:
+  main:
+    - name: "Home"
+      url: "/"
+    - name: "Blog"
+      url: "/blog/"
+    - name: "Twitter"
+      url: "https://twitter.com/GothamHQ_"
+      newtab: true
+```
+
+In the example above, the homepage and the blog will open in the same tab when clicked, as expected.
+The Twitter menu item will open in a new tab.
+This is a common practice when linking to external URLs.

--- a/navigation/menu.go
+++ b/navigation/menu.go
@@ -1,4 +1,5 @@
 // Copyright 2019 The Hugo Authors. All rights reserved.
+// Copyright 2020 The Gotham Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,6 +40,7 @@ type MenuEntry struct {
 	Weight        int
 	Parent        string
 	Children      Menu
+	NewTab        bool
 }
 
 func (m *MenuEntry) URL() string {
@@ -127,8 +129,19 @@ func (m *MenuEntry) MarshallMap(ime map[string]interface{}) {
 			m.Identifier = cast.ToString(v)
 		case "parent":
 			m.Parent = cast.ToString(v)
+		case "newtab":
+			m.NewTab = cast.ToBool(v)
 		}
 	}
+}
+
+func (m *MenuEntry) NewTabHTML() template.HTMLAttr {
+
+	if m.NewTab {
+		return `target="_blank"`
+	}
+
+	return ""
 }
 
 func (m Menu) Add(me *MenuEntry) Menu {


### PR DESCRIPTION
Adds the ability for a Gotham menu item to say its URL should be opened in a new tab.

Closes: #29