### PR TITLE
Use Gotham rather than Hugo in HTML meta generator tag.

### DIFF
--- a/hugolib/gotham-genertor_test.go
+++ b/hugolib/gotham-genertor_test.go
@@ -1,0 +1,63 @@
+// Copyright 2020 Gotham Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package hugolib
+
+// This file should be in the "transform/metainject" package because that's
+// where the code it's testing lives. Unfortunately, the test site tools we
+// need are in this "hugolib" package and are not exported. So for now, this
+// test file will live here.
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gothamhq/gotham/common/hugo"
+)
+
+// Test if the Gotham meta generator tag was injected into the homepage correctly
+func TestGothamGeneratorInject(t *testing.T) {
+
+	t.Parallel()
+
+	siteConfig := `
+baseurl = "http://example.com"
+title = "Section Menu"
+
+[[menu.main]]
+    name    = "Home"
+	url     = "/"
+	weight  = -1
+[[menu.main]]
+    name    = "Blog"
+	url     = "/blog/"
+	newtab  = false
+`
+
+	htmlTemplate := `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>HTML5 boilerplate – all you really need…</title>
+	<link rel="stylesheet" href="css/style.css">
+</head>
+<body id="home">
+	<h1>{{ .Title }}</h1>
+	<p>{{ .Permalink }}</p>
+</body>
+</html>
+`
+
+	b := newTestSitesBuilder(t).WithConfigFile("toml", siteConfig)
+	b.WithTemplatesAdded("layouts/index.html", htmlTemplate)
+	b.Build(BuildCfg{})
+
+	// Check if our Gotham meta gen tag is present
+	metaGenTag := fmt.Sprintf(`<meta name="generator" content="Gotham %s" />`, hugo.GothamVersion)
+	b.AssertHome(metaGenTag)
+
+	// Make sure that the Hugo meta gen tag is not present
+	metaGenTag = fmt.Sprintf(`<meta name="generator" content="Hugo %s" />`, hugo.CurrentVersion)
+	b.AssertFileContentInvert("public/index.html", metaGenTag)
+}

--- a/hugolib/testhelpers_test.go
+++ b/hugolib/testhelpers_test.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Hugo Authors. All rights reserved.
+// Copyright 2020 The Gotham Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package hugolib
 
 import (
@@ -716,6 +720,30 @@ func (s *sitesBuilder) AssertFileContent(filename string, matches ...string) {
 			}
 			if !strings.Contains(content, match) {
 				s.Fatalf("No match for %q in content for %s\n%s\n%q", match, filename, content, content)
+			}
+		}
+	}
+}
+
+// This works like AssertFileContent, but makes sure that there isn't a match.
+func (s *sitesBuilder) AssertFileContentInvert(filename string, matches ...string) {
+
+	s.T.Helper()
+
+	content := s.FileContent(filename)
+
+	for _, m := range matches {
+		lines := strings.Split(m, "\n")
+		for _, match := range lines {
+
+			match = strings.TrimSpace(match)
+
+			if match == "" {
+				continue
+			}
+
+			if strings.Contains(content, match) {
+				s.Fatalf("Match for %q in content for %s\n%s\n%q", match, filename, content, content)
 			}
 		}
 	}

--- a/transform/metainject/hugogenerator.go
+++ b/transform/metainject/hugogenerator.go
@@ -1,4 +1,5 @@
 // Copyright 2018 The Hugo Authors. All rights reserved.
+// Copyright 2020 The Gotham Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,14 +25,14 @@ import (
 )
 
 var metaTagsCheck = regexp.MustCompile(`(?i)<meta\s+name=['|"]?generator['|"]?`)
-var hugoGeneratorTag = fmt.Sprintf(`<meta name="generator" content="Hugo %s" />`, hugo.CurrentVersion)
+var hugoGeneratorTag = fmt.Sprintf(`<meta name="generator" content="Gotham %s" />`, hugo.GothamVersion)
 
-// HugoGenerator injects a meta generator tag for Hugo if none present.
+// HugoGenerator injects a meta generator tag for Gotham if none present.
 func HugoGenerator(ft transform.FromTo) error {
 	b := ft.From().Bytes()
 	if metaTagsCheck.Match(b) {
 		if _, err := ft.To().Write(b); err != nil {
-			helpers.DistinctWarnLog.Println("Failed to inject Hugo generator tag:", err)
+			helpers.DistinctWarnLog.Println("Failed to inject Gotham generator tag:", err)
 		}
 		return nil
 	}
@@ -47,7 +48,7 @@ func HugoGenerator(ft transform.FromTo) error {
 	}
 
 	if _, err := ft.To().Write(newcontent); err != nil {
-		helpers.DistinctWarnLog.Println("Failed to inject Hugo generator tag:", err)
+		helpers.DistinctWarnLog.Println("Failed to inject Gotham generator tag:", err)
 	}
 
 	return nil


### PR DESCRIPTION
Generates the HTML meta data with Gotham rather than Hugo.

Before change:
```
<meta name="generator" content="Hugo 0.72.0" />
```

After change:
```
<meta name="generator" content="Gotham 0.1.0" />
```

Closes: #32 