### PR TITLE
Goreleaser static snapshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,32 +6,32 @@ orbs:
 workflows:
   main:
     jobs:
+      - test-on-linux
+      - test-on-macos
+      - release-on-linux
+      - release-on-macos
+  release:
+    jobs:
       - test-on-linux:
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v\d+\.\d+\.\d+$/
       - test-on-macos:
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v\d+\.\d+\.\d+$/
       - release-on-linux:
           requires:
             - test-on-linux
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
           context: main-context
       - release-on-macos:
           requires:
             - test-on-macos
             - release-on-linux
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
           context: main-context
 
 jobs:
@@ -128,9 +128,18 @@ jobs:
             curl -sSL "https://github.com/goreleaser/goreleaser/releases/download/v0.137.0/goreleaser_Linux_x86_64.tar.gz" | sudo tar -xz -C /usr/local/bin goreleaser
             goreleaser --version
       - run:
-          name: "Release"
+          name: "Build Snapshot or Release"
           command: |
-            goreleaser release --config=.goreleaser.linux.yml
+            if [[ $CIRCLE_TAG == "" ]]; then
+              goreleaser release --config=.goreleaser.linux.yml --snapshot --skip-publish
+            else
+              goreleaser release --config=.goreleaser.linux.yml
+            fi
+
+            echo "Some information about this binary built by GoReleaser:"
+            echo "======================================================="
+            ls -lah dist/*/gotham
+            dist/*/gotham version --type=detailed
   release-on-macos:
     macos:
       xcode: 11.5.0
@@ -147,6 +156,15 @@ jobs:
             curl -sSL "https://github.com/goreleaser/goreleaser/releases/download/v0.137.0/goreleaser_Darwin_x86_64.tar.gz" | sudo tar -xz -C /usr/local/bin goreleaser
             goreleaser --version
       - run:
-          name: "Release"
+          name: "Build Snapshot or Release"
           command: |
-            goreleaser release --config=.goreleaser.macos.yml
+            if [[ $CIRCLE_TAG == "" ]]; then
+              goreleaser release --config=.goreleaser.macos.yml --snapshot --skip-publish
+            else
+              goreleaser release --config=.goreleaser.macos.yml
+            fi
+
+            echo "Some information about this binary built by GoReleaser:"
+            echo "======================================================="
+            ls -lah dist/*/gotham
+            dist/*/gotham version --type=detailed

--- a/.goreleaser.linux.yml
+++ b/.goreleaser.linux.yml
@@ -10,7 +10,7 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash=
+      - -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash= -extldflags "-static"
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
This PR contains two related changes.

1. It enables static binaries for the Linux release. Right now, this helps us in the work for #25. Now the Linux binary will run on Ubuntu 19.10 and within the snap (currently Ubuntu 18.04) without an issue. In the future, this will let us run on my Linux distros (amd64) without a problem.

2. This re-arranches the CircleCI jobs into 2 workflows. For everyday commits, the "main" workflow runs, running the two test jobs and two GoReleaser jobs all in parallel. GoReleaser will just build snapshots and not publish to GitHub. The "release" workflow only runs on releases (when we tag with a SemVer version) and runs both test jobs BEFORE the release jobs.