### PR TITLE
Update generator tag in RSS templates

### DIFF
--- a/resources/page/page_marshaljson.autogen.go
+++ b/resources/page/page_marshaljson.autogen.go
@@ -44,8 +44,8 @@ func MarshalPageToJSON(p Page) ([]byte, error) {
 	length := p.Len()
 	tableOfContents := p.TableOfContents()
 	rawContent := p.RawContent()
-	mediaType := p.MediaType()
 	resourceType := p.ResourceType()
+	mediaType := p.MediaType()
 	permalink := p.Permalink()
 	relPermalink := p.RelPermalink()
 	name := p.Name()
@@ -100,8 +100,8 @@ func MarshalPageToJSON(p Page) ([]byte, error) {
 		Len                      int
 		TableOfContents          template.HTML
 		RawContent               string
-		MediaType                media.Type
 		ResourceType             string
+		MediaType                media.Type
 		Permalink                string
 		RelPermalink             string
 		Name                     string
@@ -155,8 +155,8 @@ func MarshalPageToJSON(p Page) ([]byte, error) {
 		Len:                      length,
 		TableOfContents:          tableOfContents,
 		RawContent:               rawContent,
-		MediaType:                mediaType,
 		ResourceType:             resourceType,
+		MediaType:                mediaType,
 		Permalink:                permalink,
 		RelPermalink:             relPermalink,
 		Name:                     name,

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -37,7 +37,7 @@ var EmbeddedTemplates = [][2]string{
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <generator>Gotham -- gothamhq.com</generator>{{ with .Site.LanguageCode }}
     <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
     <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
     <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}

--- a/tpl/tplimpl/embedded/templates/_default/rss.xml
+++ b/tpl/tplimpl/embedded/templates/_default/rss.xml
@@ -16,7 +16,7 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <generator>Gotham -- gothamhq.com</generator>{{ with .Site.LanguageCode }}
     <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
     <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
     <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}


### PR DESCRIPTION
Updated rss generator tag to reference Gotham in tpl/tplimpl/embedded/templates/_default/rss.xml

I also ran `mage generate` after the change and it updated two files.

closes: #60 