### PR TITLE
Error message update

### DIFF
--- a/commands/commandeer.go
+++ b/commands/commandeer.go
@@ -1,4 +1,5 @@
 // Copyright 2019 The Hugo Authors. All rights reserved.
+// Copyright 2020 The Gotham Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -125,7 +126,7 @@ func (c *commandeer) getErrorWithContext() interface{} {
 	m := make(map[string]interface{})
 
 	m["Error"] = errors.New(removeErrorPrefixFromLog(c.logger.Errors()))
-	m["Version"] = hugo.BuildVersionString()
+	m["Version"] = hugo.PrintGothamVersion(hugo.VersionDetailed)
 
 	fe := herrors.UnwrapErrorWithFileContext(c.buildErr)
 	if fe != nil {

--- a/common/hugo/version.go
+++ b/common/hugo/version.go
@@ -128,7 +128,7 @@ func (v Version) NextPatchLevel(level int) Version {
 // BuildVersionString creates a version string. This is what you see when
 // running "hugo version".
 func BuildVersionString() string {
-	program := "Gotham Static Site Generator"
+	program := "Hugo Static Site Generator"
 
 	version := "v" + CurrentVersion.String()
 	if commitHash != "" {


### PR DESCRIPTION
Changed the function that is called when an error is caught in browser.
Reset BuildVersionString() to reference Hugo.

Closes: #61 