### PR TITLE
Release: Gotham v0.4.0

### DIFF
--- a/common/hugo/version-gotham.go
+++ b/common/hugo/version-gotham.go
@@ -9,5 +9,5 @@ var GothamVersion = SemVerVersion{
 	Major:  0,
 	Minor:  4,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
This release of Gotham includes updates from Hugo v0.74.1.
There were no other significant changes to the code base.

Gotham v0.4.0 (compatible with Hugo v0.74.1/extended)