### PR TITLE
Add fork tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ orbs:
 workflows:
   main:
     jobs:
+      - generic-tests
       - test-on-linux
       - test-on-macos
       - release-on-linux
@@ -15,6 +16,12 @@ workflows:
             - release-on-linux
   release:
     jobs:
+      - generic-tests:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
       - test-on-linux:
           filters:
             branches:
@@ -57,6 +64,15 @@ workflows:
           context: main-context
 
 jobs:
+  generic-tests:
+    docker:
+      - image: cimg/base:2020.06
+    working_directory: "~/gotham"
+    steps:
+      - checkout
+      - run:
+          name: "Fork Tests"
+          command: ./scripts/fork-tests.sh
   test-on-linux:
     machine:
       image: ubuntu-1604:202007-01

--- a/scripts/fork-tests.sh
+++ b/scripts/fork-tests.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# These are a few simple test to make sure the repository directory is as we expect.
+# This is mostly used to prevent errors when merging upstream changes.
+# This should be ran from the root of the repository.
+
+failed=""
+
+# Make sure the ./docs directory doesn't exist
+if [[ -d "./docs" ]];then
+	echo "Error: The directory './docs' shouldn't exist."
+	failed="true"
+fi
+
+# Make sure that we pulled an actual release and not a dev version
+if grep -q "DEV" ./common/hugo/version_current.go;then
+	echo "Error: It looks like a dev version of Hugo was pulled."
+	failed="true"
+fi
+
+if [[ $failed != "" ]];then
+	echo "One or more tests failed."
+	exit 1
+else
+	echo "All the \"Fork Tests\" passed."
+fi


### PR DESCRIPTION
A small collection of tests to help make sure the repo remains the way we expect it to. This should help capture issues with pulling upstream.