### PR TITLE
Release: Gotham v0.5.0

### DIFF
--- a/common/hugo/version-gotham.go
+++ b/common/hugo/version-gotham.go
@@ -9,5 +9,5 @@ var GothamVersion = SemVerVersion{
 	Major:  0,
 	Minor:  5,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
This release of Gotham includes changes from Hugo v0.74.2.

Gotham v0.5.0 (compatible with Hugo v0.74.2/extended)

---

Went with a minor release because there's a lot of work to cherry pick the upstream changes. Especially since, with the double merge commits, not all pieces show a commit hash.