### PR TITLE
shortcode: Allow start/stop params for YouTube.

### DIFF
--- a/gotham-features.md
+++ b/gotham-features.md
@@ -63,4 +63,5 @@ gotham serve --open
 
 ### YouTube Shortcode
 
-The shortcode has a title parameter.
+- The shortcode has a title parameter.
+- The shortcode has start and stop parameters, measured in seconds.

--- a/hugolib/embedded_shortcodes_test.go
+++ b/hugolib/embedded_shortcodes_test.go
@@ -189,6 +189,11 @@ func TestShortcodeYoutube(t *testing.T) {
 			`{{< youtube id="w7Ft2ymGmfc" class="youtube" title="My Video Custom Title" >}}`,
 			"(?s)\n<div class=\"youtube\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\" allowfullscreen title=\"My Video Custom Title\">.*?</iframe>.*?</div>",
 		},
+		// set class start and stop times
+		{
+			`{{< youtube id="w7Ft2ymGmfc" start="5" end="25" class="youtube" >}}`,
+			"(?s)\n<div class=\"youtube\">.*?<iframe src=\"https://www.youtube.com/embed/w7Ft2ymGmfc\\?start=5&amp;end=25\".*?allowfullscreen title=\"YouTube Video\">.*?</iframe>.*?</div>\n",
+		},
 	} {
 		var (
 			cfg, fs = newTestCfg()

--- a/tpl/tplimpl/embedded/templates.autogen.go
+++ b/tpl/tplimpl/embedded/templates.autogen.go
@@ -528,8 +528,13 @@ if (!doNotTrack) {
 {{- $id := .Get "id" | default (.Get 0) -}}
 {{- $class := .Get "class" | default (.Get 1) -}}
 {{- $title := .Get "title" | default "YouTube Video" }}
+{{ $urlParams := slice }}
+{{ with .Get "autoplay" }}{{ $urlParams = $urlParams | append "autoplay=1" }}{{ end }}
+{{ with .Get "start" }}{{ $urlParams = $urlParams | append (print "start=" .) }}{{ end }}
+{{ with .Get "end" }}{{ $urlParams = $urlParams | append (print "end=" .) }}{{ end }}
+{{ $urlParamsStr := delimit $urlParams "&" }}
 <div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"{{ end }}>
-	<iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with .Get "autoplay" }}{{ if eq . "true" }}?autoplay=1{{ end }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}"></iframe>
+	<iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ if gt (len $urlParams) 0 }}?{{ $urlParamsStr | safeURL }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}"></iframe>
 </div>
 {{ end -}}
 `},

--- a/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
+++ b/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
@@ -4,7 +4,12 @@
 {{- $id := .Get "id" | default (.Get 0) -}}
 {{- $class := .Get "class" | default (.Get 1) -}}
 {{- $title := .Get "title" | default "YouTube Video" }}
+{{ $urlParams := slice }}
+{{ with .Get "autoplay" }}{{ $urlParams = $urlParams | append "autoplay=1" }}{{ end }}
+{{ with .Get "start" }}{{ $urlParams = $urlParams | append (print "start=" .) }}{{ end }}
+{{ with .Get "end" }}{{ $urlParams = $urlParams | append (print "end=" .) }}{{ end }}
+{{ $urlParamsStr := delimit $urlParams "&" }}
 <div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"{{ end }}>
-	<iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with .Get "autoplay" }}{{ if eq . "true" }}?autoplay=1{{ end }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}"></iframe>
+	<iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ if gt (len $urlParams) 0 }}?{{ $urlParamsStr | safeURL }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}"></iframe>
 </div>
 {{ end -}}


### PR DESCRIPTION
Closes #83.

Also tested on my personal website to make sure the start/stop parameters actually work with a real video.