### PR TITLE
Release: Gotham v0.6.0

### DIFF
--- a/common/hugo/version-gotham.go
+++ b/common/hugo/version-gotham.go
@@ -9,5 +9,5 @@ var GothamVersion = SemVerVersion{
 	Major:  0,
 	Minor:  6,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
This release of Gotham includes an update to Youtube Shortcode and changes from Hugo v0.74.3.

YouTube Shortcode updates include:

- The shortcode has a title parameter.
- The shortcode has start and stop parameters, measured in seconds.

The above is also included in gotham-features.md for reference.

Gotham v0.6.0 (compatible with Hugo v0.74.3/extended)