### PR TITLE
Fix GoReleaser files.

### DIFF
--- a/.goreleaser.linux.yml
+++ b/.goreleaser.linux.yml
@@ -10,7 +10,7 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash= -extldflags "-static"
+      - -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash={{ .ShortCommit }} -extldflags "-static"
 
 archives:
   - format: tar.gz

--- a/.goreleaser.macos.yml
+++ b/.goreleaser.macos.yml
@@ -10,7 +10,8 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash=
+      #  -extldflags "-static" is purposely left out on macOS due to compiling libSASS
+      - -s -w -X github.com/gothamhq/gotham/common/hugo.buildDate={{.Date}} -X github.com/gothamhq/gotham/common/hugo.commitHash={{ .ShortCommit }}
 
 archives:
   - format: tar.gz
@@ -28,7 +29,7 @@ changelog:
   skip: true
 
 brews:
-  - github:
+  - tap:
       owner: gothamhq
       name: homebrew-tap
     commit_author:


### PR DESCRIPTION
We were missing the commit hash for both macOS and Linux. This adds that back.

Also, replaced [a deprecated term](https://goreleaser.com/deprecations/) for Brew in GoReleaser.