### PR TITLE
Update lastMod date in page_test.go to current date

### DIFF
--- a/src/hugolib/page_test.go
+++ b/src/hugolib/page_test.go
@@ -830,14 +830,14 @@ func TestPageWithLastmodFromGitInfo(t *testing.T) {
 	enSite := h.Sites[0]
 	c.Assert(len(enSite.RegularPages()), qt.Equals, 1)
 
-	// 2018-03-11 is the Git author date for testsite/content/first-post.md
-	c.Assert(enSite.RegularPages()[0].Lastmod().Format("2006-01-02"), qt.Equals, "2020-08-16")
+	// This should be the date that testsite/content/first-post.md was modified via Git
+	c.Assert(enSite.RegularPages()[0].Lastmod().Format("2006-01-02"), qt.Equals, "2020-08-19")
 
 	nnSite := h.Sites[1]
 	c.Assert(len(nnSite.RegularPages()), qt.Equals, 1)
 
-	// 2018-08-11 is the Git author date for testsite/content_nn/first-post.md
-	c.Assert(nnSite.RegularPages()[0].Lastmod().Format("2006-01-02"), qt.Equals, "2020-08-16")
+	// This should be the date that testsite/content_nn/first-post.md was modified via Git
+	c.Assert(nnSite.RegularPages()[0].Lastmod().Format("2006-01-02"), qt.Equals, "2020-08-19")
 
 }
 


### PR DESCRIPTION
This fixes an error with a test that was caused when the Go code was moved to the src folder. The test is looking at the last modified date of test files, which changed due to the code move.