### PR TITLE
Change Goldmark Renderer Unsafe to true by default

### DIFF
--- a/src/markup/goldmark/goldmark_config/config.go
+++ b/src/markup/goldmark/goldmark_config/config.go
@@ -32,7 +32,7 @@ var Default = Config{
 		TaskList:       true,
 	},
 	Renderer: Renderer{
-		Unsafe: false,
+		Unsafe: true,
 	},
 	Parser: Parser{
 		AutoHeadingID:     true,


### PR DESCRIPTION
The Goldmark.Renderer.Unsafe was updated to be true by default. This allows for the use of HTML in the markdown files.

This value could be disabled by passing the below:

```
[markup]
	[markup.goldmark]
		[markup.goldmark.renderer]
			unsafe = true
```

closes: #39 