### PR TITLE
theme: undo URL change.

### DIFF
--- a/src/commands/new_theme.go
+++ b/src/commands/new_theme.go
@@ -147,7 +147,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 func (n *newThemeCmd) createThemeMD(fs *hugofs.Fs, inpath string) (err error) {
 
 	by := []byte(`# theme.toml template for a Hugo theme
-# See https://github.com/gothamhq/gothamThemes#themetoml for an example
+# See https://github.com/gohugoio/hugoThemes#themetoml for an example
 
 name = "` + strings.Title(helpers.MakeTitle(filepath.Base(inpath))) + `"
 license = "MIT"

--- a/src/hugolib/config_test.go
+++ b/src/hugolib/config_test.go
@@ -389,7 +389,7 @@ func TestLoadConfigModules(t *testing.T) {
 
 	c := qt.New(t)
 
-	// https://github.com/gothamhq/gothamThemes#themetoml
+	// https://github.com/gohugoio/hugoThemes#themetoml
 
 	const (
 		// Before Hugo 0.56 each theme/component could have its own theme.toml


### PR DESCRIPTION
When creating a new theme, the files created reference a URL that does not exist. Corrected the reference in this PR.