### PR TITLE
Release: Gotham v0.7.0

### DIFF
--- a/src/common/hugo/version-gotham.go
+++ b/src/common/hugo/version-gotham.go
@@ -9,5 +9,5 @@ var GothamVersion = SemVerVersion{
 	Major:  0,
 	Minor:  7,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
This release of Gotham includes a Windows binary and also enables you to use HTML in your markdown files by default.
This release also includes updates from Hugo v0.75.1.

Gotham v0.7.0 (compatible with Hugo v0.75.1/extended)