### PR TITLE
Release: Gotham v0.8.0

### DIFF
--- a/src/common/hugo/version-gotham.go
+++ b/src/common/hugo/version-gotham.go
@@ -9,5 +9,5 @@ var GothamVersion = SemVerVersion{
 	Major:  0,
 	Minor:  8,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
This release is just to include Hugo v0.77 and the three point releases
that came after it.

Gotham v0.8.0 (compatible with Hugo v0.77.0/extended)