### PR TITLE
Release: Gotham v0.9.0

### DIFF
--- a/src/common/hugo/version-gotham.go
+++ b/src/common/hugo/version-gotham.go
@@ -9,5 +9,5 @@ var GothamVersion = SemVerVersion{
 	Major:  0,
 	Minor:  9,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
Updating the internal Hugo code to Hugo v0.79.0.

Gotham v0.8.0 (compatible with Hugo v0.79.0/extended)