### PR TITLE
Tpl: add support for Mastodon shortcode.

### DIFF
--- a/gotham-features.md
+++ b/gotham-features.md
@@ -94,3 +94,15 @@ Resources:
 - https://developer.android.com/training/app-links/verify-site-associations
 - https://developers.google.com/digital-asset-links/tools/generator
 - https://developers.google.com/digital-asset-links/v1/getting-started
+
+### Mastodon Shortcode
+
+Embed Mastodon toots in your Gotham pages with this Mastodon shortcode.
+You can pass the toot URL and optionally, a width and height.
+Keep in mind that the width and height are considered suggestions to Mastodon and it will render mostly based on the content it's trying to show.
+
+Usage:
+
+```
+{{< mastodon url="https://mastodon.social/@Gargron/105303408810292711" >}}
+```

--- a/src/tpl/tplimpl/embedded/templates.autogen.go
+++ b/src/tpl/tplimpl/embedded/templates.autogen.go
@@ -448,6 +448,12 @@ if (!doNotTrack) {
 </style>
 {{ end }}
 {{ end }}`},
+	{`shortcodes/mastodon.html`, `{{ $url := .Get "url" | urls.Parse }}
+{{ $api := printf "%s://%s/api/oembed/?" $url.Scheme $url.Host }}
+{{ $width := .Get "width" | default "400" }}
+{{ $height := .Get "height" | default "null" }}
+{{ with getJSON $api (querify "url" $url "width" $width "height" $height) }}{{ .html | safeHTML }}{{ end }}
+`},
 	{`shortcodes/param.html`, `{{- $name := (.Get 0) -}}
 {{- with $name -}}
 {{- with ($.Page.Param .) }}{{ . }}{{ else }}{{ errorf "Param %q not found: %s" $name $.Position }}{{ end -}}

--- a/src/tpl/tplimpl/embedded/templates/shortcodes/mastodon.html
+++ b/src/tpl/tplimpl/embedded/templates/shortcodes/mastodon.html
@@ -1,0 +1,5 @@
+{{ $url := .Get "url" | urls.Parse }}
+{{ $api := printf "%s://%s/api/oembed/?" $url.Scheme $url.Host }}
+{{ $width := .Get "width" | default "400" }}
+{{ $height := .Get "height" | default "null" }}
+{{ with getJSON $api (querify "url" $url "width" $width "height" $height) }}{{ .html | safeHTML }}{{ end }}


### PR DESCRIPTION
Closes #197. 

Adds a shortcode to embed toots from [Mastodon](https://joinmastodon.org/).