### PR TITLE
Tpl: add support for Apple App Site Association.

### DIFF
--- a/gotham-features.md
+++ b/gotham-features.md
@@ -106,3 +106,19 @@ Usage:
 ```
 {{< mastodon url="https://mastodon.social/@Gargron/105303408810292711" >}}
 ```
+
+### Apple App Site Association
+
+A Gotham site can generate an associated domain file (`apple-app-site-association`) by providing two values in your Gotham config. 
+This allows you connect your app and your Gotham website to provide both a native app and a browser experience.
+
+```yaml
+#... gotham config
+aasaPrefix: "<my-application-identifier-prefix>"
+aasaBundle: "<my-bundle-identifier>"
+```
+
+Resources:
+
+- https://developer.apple.com/documentation/safariservices/supporting_associated_domains
+- https://search.developer.apple.com/appsearch-validation-tool

--- a/src/config/services/servicesConfig.go
+++ b/src/config/services/servicesConfig.go
@@ -26,6 +26,8 @@ const (
 	rssLimitKey              = "rssLimit"
 	assetLinksPackageNameKey = "assetLinksPackageName"
 	assetLinksFingerprintKey = "assetLinksFingerprint"
+	aasaPrefixKey            = "aasaPrefix"
+	aasaBundleKey            = "aasaBundle"
 )
 
 // Config is a privacy configuration for all the relevant services in Hugo.
@@ -36,6 +38,7 @@ type Config struct {
 	Twitter         Twitter
 	RSS             RSS
 	AssetLinks      AssetLinks
+	AASA            AASA
 }
 
 // Disqus holds the functional configuration settings related to the Disqus template.
@@ -78,6 +81,12 @@ type AssetLinks struct {
 	Fingerprint string
 }
 
+// AASA holds the functional configuration settings related to Apple App Site Association.
+type AASA struct {
+	Prefix string
+	Bundle string
+}
+
 // DecodeConfig creates a services Config from a given Hugo configuration.
 func DecodeConfig(cfg config.Provider) (c Config, err error) {
 	m := cfg.GetStringMap(servicesConfigKey)
@@ -101,6 +110,11 @@ func DecodeConfig(cfg config.Provider) (c Config, err error) {
 	if c.AssetLinks.PackageName == "" {
 		c.AssetLinks.PackageName = cfg.GetString(assetLinksPackageNameKey)
 		c.AssetLinks.Fingerprint = cfg.GetString(assetLinksFingerprintKey)
+	}
+
+	if c.AASA.Prefix == "" {
+		c.AASA.Prefix = cfg.GetString(aasaPrefixKey)
+		c.AASA.Bundle = cfg.GetString(aasaBundleKey)
 	}
 
 	return

--- a/src/hugolib/aasa_test.go
+++ b/src/hugolib/aasa_test.go
@@ -1,0 +1,75 @@
+// Copyright 2020 Gotham Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package hugolib
+
+import (
+	"testing"
+
+	"github.com/gothamhq/gotham/deps"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestAASAOutput(t *testing.T) {
+
+	t.Parallel()
+
+	testCases := []struct {
+		prefix  string
+		bundle  string
+		passing bool
+	}{
+		{
+			"ABCDE12345",
+			"com.gothamhq.ios",
+			true,
+		},
+		{
+			"",
+			"com.gothamhq.ios",
+			false,
+		},
+		{
+			"ABCDE12345",
+			"",
+			false,
+		},
+		{
+			"",
+			"",
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+
+		c := qt.New(t)
+		cfg, fs := newTestCfg()
+		cfg.Set("baseURL", "http://gotham/test/")
+		cfg.Set("aasaPrefix", tc.prefix)
+		cfg.Set("aasaBundle", tc.bundle)
+
+		depsCfg := deps.DepsCfg{Fs: fs, Cfg: cfg}
+
+		writeSourcesToSource(t, "content", fs, weightedSources...)
+		s := buildSingleSite(t, depsCfg, BuildCfg{})
+		th := newTestHelper(s.Cfg, s.Fs, t)
+		outputAASA := "public/.well-known/apple-app-site-association"
+
+		if !tc.passing {
+
+			th.assertFileNotExist(outputAASA)
+			return
+		}
+
+		th.assertFileContent(outputAASA,
+			tc.prefix,
+			tc.bundle,
+		)
+
+		content := readDestination(th, th.Fs, outputAASA)
+		c.Assert(content, qt.Contains, tc.prefix)
+		c.Assert(content, qt.Contains, tc.bundle)
+	}
+}

--- a/src/hugolib/page_kinds.go
+++ b/src/hugolib/page_kinds.go
@@ -37,6 +37,7 @@ const (
 	kindRobotsTXT  = "robotsTXT"
 	kind404        = "404"
 	kindAssetLinks = "assetLinks"
+	kindAASA       = "AASA"
 
 	pageResourceType = "page"
 )
@@ -47,6 +48,7 @@ var kindMap = map[string]string{
 	strings.ToLower(kindRobotsTXT):  kindRobotsTXT,
 	strings.ToLower(kind404):        kind404,
 	strings.ToLower(kindAssetLinks): kindAssetLinks,
+	strings.ToLower(kindAASA):       kindAASA,
 }
 
 func getKind(s string) string {

--- a/src/hugolib/site.go
+++ b/src/hugolib/site.go
@@ -1252,6 +1252,10 @@ func (s *Site) render(ctx *siteRenderContext) (err error) {
 		if err = s.renderAssetLinks(); err != nil {
 			return
 		}
+
+		if err = s.renderAASA(); err != nil {
+			return
+		}
 	}
 
 	if !ctx.renderSingletonPages() {

--- a/src/hugolib/site_output.go
+++ b/src/hugolib/site_output.go
@@ -45,6 +45,7 @@ func createDefaultOutputFormats(allFormats output.Formats) map[string]output.For
 		kindRobotsTXT:  {robotsOut},
 		kind404:        {htmlOut},
 		kindAssetLinks: {jsonOut},
+		kindAASA:       {jsonOut},
 	}
 
 	// May be disabled

--- a/src/hugolib/site_render.go
+++ b/src/hugolib/site_render.go
@@ -327,6 +327,41 @@ func (s *Site) renderAssetLinks() error {
 	return s.renderAndWritePage(&s.PathSpec.ProcessingStats.Pages, "assetlinks", targetPath, p, templ)
 }
 
+func (s *Site) renderAASA() error {
+
+	p, err := newPageStandalone(&pageMeta{
+		s:    s,
+		kind: kindAASA,
+		urlPaths: pagemeta.URLPath{
+			URL: ".well-known/apple-app-site-association",
+		}},
+		output.JSONFormat,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	if !p.render {
+		return nil
+	}
+
+	// only render if both config settings are set
+	if s.Cfg.GetString("aasaPrefix") == "" || s.Cfg.GetString("aasaBundle") == "" {
+		return nil
+	}
+
+	targetPath := p.targetPaths().TargetFilename
+
+	if targetPath == "" {
+		return errors.New("failed to create targetPath for Apple App Site Associate")
+	}
+
+	templ := s.lookupLayouts("apple_app_site_association.json", "_default/apple_app_site_association.json", "_internal/_default/apple_app_site_association.json")
+
+	return s.renderAndWritePage(&s.PathSpec.ProcessingStats.Pages, "Apple App Site Associate", targetPath, p, templ)
+}
+
 func (s *Site) renderRobotsTXT() error {
 	if !s.Cfg.GetBool("enableRobotsTXT") {
 		return nil

--- a/src/tpl/tplimpl/embedded/templates.autogen.go
+++ b/src/tpl/tplimpl/embedded/templates.autogen.go
@@ -18,6 +18,24 @@ package embedded
 
 // EmbeddedTemplates represents all embedded templates.
 var EmbeddedTemplates = [][2]string{
+	{`_default/apple_app_site_association.json`, `{
+	"applinks": {
+		"details": [{
+			"appIDs": [ "{{ printf "%s.%s" .Site.Config.Services.AASA.Prefix .Site.Config.Services.AASA.Bundle }}" ],
+			"components": [{
+					"#": "no_universal_links",
+					"exclude": true,
+					"comment": "Matches any URL whose fragment equals no_universal_links and instructs the system not to open it as a universal link"
+				},
+				{
+					"/": "*",
+					"comment": "Matches any URL on the domain (wildcard)"
+				}
+			]
+		}]
+	}
+}
+`},
 	{`_default/assetlinks.json`, `[{
   "relation": ["delegate_permission/common.handle_all_urls"],
   "target" : { "namespace": "android_app", "package_name": "{{ .Site.Config.Services.AssetLinks.PackageName }}",

--- a/src/tpl/tplimpl/embedded/templates/_default/apple_app_site_association.json
+++ b/src/tpl/tplimpl/embedded/templates/_default/apple_app_site_association.json
@@ -1,0 +1,17 @@
+{
+	"applinks": {
+		"details": [{
+			"appIDs": [ "{{ printf "%s.%s" .Site.Config.Services.AASA.Prefix .Site.Config.Services.AASA.Bundle }}" ],
+			"components": [{
+					"#": "no_universal_links",
+					"exclude": true,
+					"comment": "Matches any URL whose fragment equals no_universal_links and instructs the system not to open it as a universal link"
+				},
+				{
+					"/": "*",
+					"comment": "Matches any URL on the domain (wildcard)"
+				}
+			]
+		}]
+	}
+}


### PR DESCRIPTION
Closes #203 

Add support for the Apple App Site Association file to connect an iOS app to your website.