### PR TITLE
Release: Gotham v0.10.0

### DIFF
--- a/src/common/hugo/version-gotham.go
+++ b/src/common/hugo/version-gotham.go
@@ -9,5 +9,5 @@ var GothamVersion = SemVerVersion{
 	Major:  0,
 	Minor:  10,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
This is a decent size release for Gotham. It includes new shortcodes and
templates as well as a small bug fix. Enjoy!

New features:
- a shortcode for QR code generation
- support for Google's Digital Asset Links
- a shortcode for Mastodon

Fixes:
- Gotham no longer shows the commit hash via the version command for
official releases

Gotham v0.10.0 (compatible with Hugo v0.79.0/extended)