### PR TITLE
Release: Gotham v0.11.0

### DIFF
--- a/src/common/hugo/version-gotham.go
+++ b/src/common/hugo/version-gotham.go
@@ -9,5 +9,5 @@ var GothamVersion = SemVerVersion{
 	Major:  0,
 	Minor:  11,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
This Gotham release includes a few exciting updates.
It includes support for Apple's App Site Association and JSON Feed.

New features:
- support for Apple's App Site Association
- support for JSON Feed

Gotham v0.11.0 (compatible with Hugo v0.79.1/extended)