### PR TITLE
Release: Gotham v0.12.0

### DIFF
--- a/src/common/hugo/version-gotham.go
+++ b/src/common/hugo/version-gotham.go
@@ -9,5 +9,5 @@ var GothamVersion = SemVerVersion{
 	Major:  0,
 	Minor:  12,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
Includes changes from the Hugo v0.80.0 release.
One notable piece is the switch from LibSass to Dart Sass for SCSS/SASS
processing.

Gotham v0.12.0 (compatible with Hugo v0.80.0/extended)