### PR TITLE
Release: Gotham v0.13.0

### DIFF
--- a/src/common/hugo/version-gotham.go
+++ b/src/common/hugo/version-gotham.go
@@ -9,5 +9,5 @@ var GothamVersion = SemVerVersion{
 	Major:  0,
 	Minor:  13,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
This release adds v1 support for AASA links. Gotham now supports both v1
(pre-2019) and v2 (2019 and on) AASA schemas thanks to @chayev.

This release is also the last one to be called Gotham. Starting with the
v0.14.0 release Gotham will now be called Strawberry. To continue to
receive updates to Strawberry/Gotham you'll need to reinstall it. This
can be done by following the migration guide:
https://docs.strawberryssg.com/migration

Gotham v0.13.0 (compatible with Hugo v0.80.0/extended)