### PR TITLE
Release: Strawberry v0.14.0

### DIFF
--- a/src/common/hugo/version_strawberry.go
+++ b/src/common/hugo/version_strawberry.go
@@ -9,5 +9,5 @@ var StrawberryVersion = SemVerVersion{
 	Major:  0,
 	Minor:  14,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
This is the first release where Gotham has been renamed to Strawberry!
This release includes the Hugo v0.81.0 release.

Strawberry v0.14.0 (compatible with Hugo v0.81.0/extended)