### PR TITLE
Upstream: Pull in changes from Hugo v0.82.1

### DIFF
--- a/common/hugo/version_current.go
+++ b/common/hugo/version_current.go
@@ -17,6 +17,6 @@ package hugo
 // This should be the only one.
 var CurrentVersion = Version{
 	Number:     0.82,
-	PatchLevel: 0,
+	PatchLevel: 1,
 	Suffix:     "",
 }

--- a/docs/content/en/news/0.82.1-relnotes/index.md
+++ b/docs/content/en/news/0.82.1-relnotes/index.md
@@ -1,0 +1,19 @@
+
+---
+date: 2021-04-20
+title: "Hugo 0.82.1: A couple of Bug Fixes"
+description: "This version fixes a couple of bugs introduced in 0.82.0."
+categories: ["Releases"]
+images:
+- images/blog/hugo-bug-poster.png
+
+---
+
+	
+
+This is a bug-fix release with one important fix.
+
+* Regression in media type suffix lookup [6e9d2bf0](https://github.com/gohugoio/hugo/commit/6e9d2bf0c936900f8f676d485098755b3f463373) [@bep](https://github.com/bep) [#8406](https://github.com/gohugoio/hugo/issues/8406)
+
+
+

--- a/media/mediaType.go
+++ b/media/mediaType.go
@@ -303,7 +303,7 @@ func (t Types) GetBySuffix(suffix string) (tp Type, si SuffixInfo, found bool) {
 }
 
 func (m Type) hasSuffix(suffix string) bool {
-	return strings.Contains(m.suffixesCSV, suffix)
+	return strings.Contains(","+m.suffixesCSV+",", ","+suffix+",")
 }
 
 // GetByMainSubType gets a media type given a main and a sub type e.g. "text" and "plain".

--- a/media/mediaType_test.go
+++ b/media/mediaType_test.go
@@ -15,6 +15,7 @@ package media
 
 import (
 	"encoding/json"
+	"sort"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -98,11 +99,28 @@ func TestBySuffix(t *testing.T) {
 
 func TestGetFirstBySuffix(t *testing.T) {
 	c := qt.New(t)
-	_, f, found := DefaultTypes.GetFirstBySuffix("xml")
-	c.Assert(found, qt.Equals, true)
-	c.Assert(f, qt.Equals, SuffixInfo{
-		Suffix:     "xml",
-		FullSuffix: ".xml"})
+
+	types := DefaultTypes
+
+	// Issue #8406
+	geoJSON := newMediaTypeWithMimeSuffix("application", "geo", "json", []string{"geojson", "gjson"})
+	types = append(types, geoJSON)
+	sort.Sort(types)
+
+	check := func(suffix string, expectedType Type) {
+		t, f, found := types.GetFirstBySuffix(suffix)
+		c.Assert(found, qt.Equals, true)
+		c.Assert(f, qt.Equals, SuffixInfo{
+			Suffix:     suffix,
+			FullSuffix: "." + suffix})
+		c.Assert(t, qt.Equals, expectedType)
+	}
+
+	check("js", JavascriptType)
+	check("json", JSONType)
+	check("geojson", geoJSON)
+	check("gjson", geoJSON)
+
 }
 
 func TestFromTypeString(t *testing.T) {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: hugo
-version: "0.82.0"
+version: "0.82.1"
 summary: Fast and Flexible Static Site Generator
 description: |
   Hugo is a static HTML and CSS website generator written in Go. It is

--- a/temp/0.82.1-relnotes-ready.md
+++ b/temp/0.82.1-relnotes-ready.md
@@ -1,0 +1,8 @@
+
+
+This is a bug-fix release with one important fix.
+
+* Regression in media type suffix lookup [6e9d2bf0](https://github.com/gohugoio/hugo/commit/6e9d2bf0c936900f8f676d485098755b3f463373) [@bep](https://github.com/bep) [#8406](https://github.com/gohugoio/hugo/issues/8406)
+
+
+


### PR DESCRIPTION
Upstream released a patch fix that fixes a problem we specifically had in Strawberry. This was in regards to our JSON Feed support and mimetypes.