### PR TITLE
Release: Strawberry v0.15.0

### DIFF
--- a/src/common/hugo/version_strawberry.go
+++ b/src/common/hugo/version_strawberry.go
@@ -9,5 +9,5 @@ var StrawberryVersion = SemVerVersion{
 	Major:  0,
 	Minor:  15,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
This release includes changes and fixes from Hugo v0.82.0 and v0.82.1.

Strawberry v0.15.0 (compatible with Hugo v0.82.1/extended)