### PR TITLE
Switch to dynamic binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - -s -w -X github.com/strawberryssg/strawberry-v0/common/hugo.buildDate={{.Date}} -X github.com/strawberryssg/strawberry-v0/common/hugo.commitHash={{ .ShortCommit }} -extldflags "-static"
+      - -s -w -X github.com/strawberryssg/strawberry-v0/common/hugo.buildDate={{.Date}} -X github.com/strawberryssg/strawberry-v0/common/hugo.commitHash={{ .ShortCommit }}
   - id: strawberry-windows
     dir: src
     env:


### PR DESCRIPTION
A change in Hugo v0.84.x made it so that the static binaries we're
generating are causing a segmentation fault. I haven't been able to
track the specific cause nor do I have a workaround. So for the time
being, Strawberry will revert to dynamic binaries for releases.

Sometime in the future, where we can fix this issue, we'll go back to
static binaries. The GitHub Issue to track the future work can be found
here: https://github.com/strawberryssg/strawberry-v0/issues/278