### PR TITLE
Release: Strawberry v0.17.0

### DIFF
--- a/src/common/hugo/version_strawberry.go
+++ b/src/common/hugo/version_strawberry.go
@@ -9,5 +9,5 @@ var StrawberryVersion = SemVerVersion{
 	Major:  0,
 	Minor:  17,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
This release includes changes and fixes from Hugo v0.84.x and v0.85.0.

Strawberry v0.17.0 (compatible with Hugo v0.85.0/extended)