### PR TITLE
Release: Strawberry v0.19.0

### DIFF
--- a/src/common/hugo/version_strawberry.go
+++ b/src/common/hugo/version_strawberry.go
@@ -9,5 +9,5 @@ var StrawberryVersion = SemVerVersion{
 	Major:  0,
 	Minor:  19,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
This release includes changes and fixes from Hugo v0.88.0.

Strawberry v0.19.0 (compatible with Hugo v0.88.0/extended)