### PR TITLE
Release: Strawberry v0.20.1

### DIFF
--- a/src/common/hugo/version_strawberry.go
+++ b/src/common/hugo/version_strawberry.go
@@ -7,7 +7,7 @@ package hugo
 // There's an include base version of Hugo in a different file.
 var StrawberryVersion = SemVerVersion{
 	Major:  0,
-	Minor:  21,
-	Patch:  0,
-	Suffix: "dev",
+	Minor:  20,
+	Patch:  1,
+	Suffix: "",
 }


### PR DESCRIPTION
Fixing the version output when running `strawberry serve`. Before this
fix, it was outputting the Hugo version instead of the Strawberry
version.

Strawberry v0.20.1 (compatible with Hugo v0.89.4/extended)