### PR TITLE
Release: Strawberry v0.21.0

### DIFF
--- a/src/common/hugo/version_strawberry.go
+++ b/src/common/hugo/version_strawberry.go
@@ -9,5 +9,5 @@ var StrawberryVersion = SemVerVersion{
 	Major:  0,
 	Minor:  21,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
This release includes the new "Strawberry File" as well as a warning
when building a site not as the root of the hostname. The warning covers
files that only work when they exists at the root. This release bumps
the Hugo base version to 0.90.1.

Strawberry v0.21.0 (compatible with Hugo v0.90.1/extended)