### PR TITLE
Release: Strawberry v0.22.0

### DIFF
--- a/src/common/hugo/version_strawberry.go
+++ b/src/common/hugo/version_strawberry.go
@@ -9,5 +9,5 @@ var StrawberryVersion = SemVerVersion{
 	Major:  0,
 	Minor:  22,
 	Patch:  0,
-	Suffix: "dev",
+	Suffix: "",
 }


### PR DESCRIPTION
This release includes changes from Hugo v0.92.1 and will be the last
release to support LibSASS. Dart Sass will be enabled by default with
the next minor release of Strawberry and LibSASS support removed. Hugo's
doc on the need for embedded Dart Sass can be found here:
https://gohugo.io/hugo-pipes/scss-sass/

Strawberry v0.22.0 (compatible with Hugo v0.92.1/extended)